### PR TITLE
Fix convert_to_dict type check

### DIFF
--- a/call_server/utils.py
+++ b/call_server/utils.py
@@ -57,7 +57,7 @@ def duplicate_object(orig, skip=None):
 
 def convert_to_dict(obj):
     """converts tuples of tuples to OrderedDict for easy lookup that maintains order"""
-    if type(obj) is not dict():
+    if not isinstance(obj, dict):
         try:
             dictlike = OrderedDict(obj)
             return dictlike

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,19 @@
+from collections import OrderedDict
+import importlib.util
+from pathlib import Path
+
+# Import call_server/utils.py without triggering call_server package imports
+spec = importlib.util.spec_from_file_location("call_server.utils", Path(__file__).resolve().parents[1] / "call_server" / "utils.py")
+utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(utils)
+convert_to_dict = utils.convert_to_dict
+
+
+def test_convert_to_dict_returns_dict_unchanged():
+    data = {'a': 1, 'b': 2}
+    assert convert_to_dict(data) == data
+
+
+def test_convert_to_dict_converts_tuples_to_ordered_dict():
+    data = (('a', 1), ('b', 2))
+    assert convert_to_dict(data) == OrderedDict([('a', 1), ('b', 2)])


### PR DESCRIPTION
## Summary
- ensure `convert_to_dict` skips conversion when given a dict
- add tests for `convert_to_dict`

## Testing
- `pytest tests/test_utils.py`
- `pytest` *(fails: ModuleNotFoundError: tests/test_admin_blocklist.py, tests/test_ca_data.py, tests/test_geocoders.py, tests/test_political_data_adapters.py, tests/test_us_data.py, tests/test_us_state_data.py, src/python-actionkit/actionkit/test_models.py)*

------
https://chatgpt.com/codex/tasks/task_e_6897c85c4038832491a76f8f8585f0a5