### PR TITLE
Fix typo in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Installation Instructions
 -------------------
 This application should be easy to host on Heroku, with Docker, or directly on any WSGI-compatible server. Requires Python, flask, a SQL database (we recommend Postgres, but Mysql should work), Redis or Memcache, and an SMTP server.
 
-Read detailed instrustions at [INSTALLATION.md](INSTALLATION.md)
+Read detailed instructions at [INSTALLATION.md](INSTALLATION.md)
 
 Testing
 -------


### PR DESCRIPTION
## Summary
- fix typo in README installation instructions

## Testing
- `python tests/run.py` *(fails: AttributeError: module 'collections' has no attribute 'MutableMapping')*

------
https://chatgpt.com/codex/tasks/task_e_6897c9bbb2e48324ae3f219872d8e62c