### PR TITLE
docs: document python 3.11 requirement

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,10 +1,11 @@
 Installation
 ==============
+CallPower requires Python 3.11. Ensure it is installed before continuing.
 
 Configure Settings
 ------------
 
-The app requires several account keys to run. These should not be stored in version control, but in environment variables. For development, you can export these from your virtualenv/bin/activate script, or put them in a .env file and load them with [autoenv](https://github.com/kennethreitz/autoenv).
+The app requires several account keys to run. These should not be stored in version control, but in environment variables. For development, you can export these from your `.venv/bin/activate` script, or put them in a .env file and load them with [autoenv](https://github.com/kennethreitz/autoenv).
 
 At a minimum, you will need to set:
 
@@ -60,7 +61,7 @@ Development mode
 To install locally and run in debug mode use:
 
     # create ENV variables
-    virtualenv .venv
+    python3.11 -m venv .venv
     source .venv/bin/activate
     pip install -r requirements/development.txt
     export FLASK_APP=manager.py; FLASK_ENV=development; FLASK_DEBUG=1


### PR DESCRIPTION
## Summary
- document that CallPower requires Python 3.11
- use `python3.11 -m venv` in development setup instructions

## Testing
- `python tests/run.py` *(fails: AttributeError: module 'collections' has no attribute 'MutableMapping')*

------
https://chatgpt.com/codex/tasks/task_e_6897cc95ba6483249b85c49df5c5da10