### PR TITLE
Fix Python 3.11 compatibility

### DIFF
--- a/call_server/campaign/forms.py
+++ b/call_server/campaign/forms.py
@@ -2,15 +2,32 @@ import magic
 from flask_wtf import FlaskForm
 from flask_babel import gettext as _
 
-from wtforms import (HiddenField, SubmitField, TextField,
-                     SelectField, SelectMultipleField,
-                     BooleanField, RadioField,
-                     FileField, FieldList, FormField)
-from wtforms.ext.sqlalchemy.fields import QuerySelectField, QuerySelectMultipleField
+from wtforms import (
+    HiddenField,
+    SubmitField,
+    StringField,
+    SelectField,
+    SelectMultipleField,
+    BooleanField,
+    RadioField,
+    FileField,
+    FieldList,
+    FormField,
+)
+TextField = StringField
+from wtforms_sqlalchemy.fields import QuerySelectField, QuerySelectMultipleField
 from wtforms_components import IntegerField, read_only
 from wtforms_alchemy import PhoneNumberField
 from wtforms.widgets import TextArea, Input
-from wtforms.validators import Required, Optional, AnyOf, NumberRange, ValidationError, Length
+from wtforms.validators import (
+    DataRequired,
+    Optional,
+    AnyOf,
+    NumberRange,
+    ValidationError,
+    Length,
+)
+Required = DataRequired
 from wtforms_alchemy.validators import Unique
 
 from .constants import (SEGMENT_BY_CHOICES, LOCATION_CHOICES, INCLUDE_SPECIAL_CHOCIES, TARGET_OFFICE_CHOICES, LANGUAGE_CHOICES,

--- a/call_server/campaign/views.py
+++ b/call_server/campaign/views.py
@@ -2,7 +2,7 @@ import datetime
 
 from flask import (Blueprint, render_template, current_app, request,
                    flash, url_for, redirect, session, abort, jsonify)
-from flask.json import JSONEncoder
+import json
 from flask_login import login_required
 from flask_store.providers.temp import TemporaryStore
 
@@ -133,7 +133,7 @@ def form(country_code=None, campaign_type=None, campaign_id=None, campaign_langu
     for number in TwilioPhoneNumber.available_numbers().filter_by(call_in_allowed=True):
         if campaign.id != number.call_in_campaign.id:
             call_in_map[number.id] = number.call_in_campaign.name
-    form.phone_number_set.render_kw = { "data-call_in_map": JSONEncoder().encode(call_in_map) }
+    form.phone_number_set.render_kw = { "data-call_in_map": json.dumps(call_in_map) }
 
     # for fields with dynamic choices, set to empty here in view
     # will be updated in client

--- a/call_server/extensions.py
+++ b/call_server/extensions.py
@@ -24,6 +24,50 @@ mail = Mail()
 from flask_login import LoginManager
 login_manager = LoginManager()
 
+# ``flask-restless`` depends on the deprecated ``url_quote_plus`` helper that
+# was removed in Werkzeug 3. To maintain compatibility we reintroduce the
+# function using :func:`urllib.parse.quote_plus` before importing
+# ``flask_restless``.
+import urllib.parse
+import hmac
+import json
+import jinja2
+from markupsafe import Markup
+import flask
+import flask.json as flask_json
+import werkzeug
+import werkzeug.security as _wz_security
+from werkzeug import urls as _werkzeug_urls
+
+# ---------------------------------------------------------------------------
+# Compatibility shims for newer Flask/Werkzeug ecosystems.  Several of the
+# pinned third-party dependencies import helpers that were removed in recent
+# releases.  We provide stand-ins here so that those packages continue to work
+# without modification.
+# ---------------------------------------------------------------------------
+if not hasattr(_werkzeug_urls, "url_quote_plus"):  # pragma: no cover
+    _werkzeug_urls.url_quote_plus = urllib.parse.quote_plus
+
+if not hasattr(_wz_security, "safe_str_cmp"):  # pragma: no cover
+    _wz_security.safe_str_cmp = hmac.compare_digest
+
+if not hasattr(werkzeug, "url_encode"):  # pragma: no cover
+    werkzeug.url_encode = urllib.parse.urlencode
+
+if not hasattr(werkzeug, "LocalProxy"):  # pragma: no cover
+    from werkzeug.local import LocalProxy as _LocalProxy
+
+    werkzeug.LocalProxy = _LocalProxy
+
+if not hasattr(flask, "Markup"):  # pragma: no cover
+    flask.Markup = Markup
+
+if not hasattr(flask_json, "JSONEncoder"):  # pragma: no cover
+    flask_json.JSONEncoder = json.JSONEncoder
+
+if not hasattr(jinja2, "Markup"):  # pragma: no cover
+    jinja2.Markup = Markup
+
 from flask_restless import APIManager
 rest = APIManager()
 

--- a/call_server/user/forms.py
+++ b/call_server/user/forms.py
@@ -1,15 +1,30 @@
 # -*- coding: utf-8 -*-
 
-from flask import Markup
+from markupsafe import Markup
 
 from flask_wtf import FlaskForm
 from flask_babel import gettext as _
-from wtforms import (HiddenField, BooleanField, TextField,
-                     PasswordField, SubmitField,
-                     RadioField, DateField)
-from wtforms.validators import ValidationError, Required, Length, EqualTo, Email, AnyOf
+from wtforms import (
+    HiddenField,
+    BooleanField,
+    StringField,
+    PasswordField,
+    SubmitField,
+    RadioField,
+    DateField,
+)
+TextField = StringField
+from wtforms.validators import (
+    ValidationError,
+    DataRequired,
+    Length,
+    EqualTo,
+    Email,
+    AnyOf,
+)
+Required = DataRequired
 from wtforms_alchemy import PhoneNumberField
-from wtforms.fields.html5 import EmailField
+from wtforms.fields import EmailField
 
 from .models import User
 from .constants import (PASSWORD_LEN_MIN, PASSWORD_LEN_MAX,

--- a/call_server/user/models.py
+++ b/call_server/user/models.py
@@ -2,7 +2,7 @@ from datetime import datetime
 import functools
 
 from sqlalchemy_utils.types import phone_number
-from werkzeug import generate_password_hash, check_password_hash
+from werkzeug.security import generate_password_hash, check_password_hash
 from flask_login import UserMixin
 
 from ..extensions import db

--- a/call_server/utils.py
+++ b/call_server/utils.py
@@ -11,11 +11,11 @@ import yaml.constructor
 from collections import OrderedDict
 from datetime import datetime
 
-from flask import Markup
+from markupsafe import Markup
 import sqlalchemy
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.exc import IntegrityError
-from werkzeug import FileStorage
+from werkzeug.datastructures import FileStorage
 
 
 # near copy of django's get_or_create, modified from http://stackoverflow.com/a/21146492/264790


### PR DESCRIPTION
## Summary
- shim missing `collections` ABCs to unblock Python 3.11
- update Flask/Werkzeug dependent imports and validators
- add compatibility helpers for deprecated Werkzeug/Flask utilities

## Testing
- `python tests/run.py`

------
https://chatgpt.com/codex/tasks/task_e_68980d2a8b4c83249bb24defbfaab735